### PR TITLE
refactor: BuildSpec一元化とSecrets Manager廃止

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'infra/**'
+      - 'amplify.yml'
       - '.github/workflows/deploy-infra.yml'
   workflow_dispatch:
     inputs:
@@ -66,10 +67,14 @@ jobs:
 
       - name: CDK Diff
         working-directory: infra
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
         run: npx cdk diff
 
       - name: CDK Deploy
         working-directory: infra
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
         run: npx cdk deploy --require-approval never --outputs-file cdk-outputs.json
 
       - name: Upload CDK Outputs


### PR DESCRIPTION
## 概要
BuildSpec設定の一元化とSecrets Manager廃止によるコスト削減・メンテナンス性向上

## 変更内容
### amplify-stack.ts
- BuildSpecを `amplify.yml` ファイルから読み込むよう変更（一元化）
- Secrets Manager 廃止、`GITHUB_TOKEN` 環境変数で対応

### deploy-infra.yml
- `GH_PAT` シークレットから `GITHUB_TOKEN` 環境変数を設定

### deployment.md
- ドキュメント更新（Secrets Manager → 環境変数）

## メリット
- ��� Secrets Manager 利用料金の削減
- ��� BuildSpec 設定の一元管理（amplify.yml のみ）