### PR TITLE
feat: .envファイルによる環境変数管理をサポート

### DIFF
--- a/docs/30_operations/deployment.md
+++ b/docs/30_operations/deployment.md
@@ -82,13 +82,24 @@ export USE_SECRETS_MANAGER=false
 
 ### 1.1 AWS 認証の設定
 
+**方法A: .env ファイル（推奨）**
+
+`infra/.env` ファイルを作成し、必要な値を設定します（`.env.example` を参照）。
+
 ```bash
-# 方法A: 環境変数
+cp infra/.env.example infra/.env
+# infra/.env を編集して認証情報を設定
+```
+
+**方法B: 環境変数（直接エクスポート）**
+```bash
 export AWS_ACCESS_KEY_ID=xxxxx
 export AWS_SECRET_ACCESS_KEY=xxxxx
 export AWS_DEFAULT_REGION=ap-northeast-1
+```
 
-# 方法B: AWS SSO（推奨）
+**方法C: AWS SSO**
+```bash
 aws sso login --profile your-profile
 export AWS_PROFILE=your-profile
 ```
@@ -98,7 +109,7 @@ export AWS_PROFILE=your-profile
 ```bash
 cd infra
 
-# Secrets Manager を使用（推奨）
+# .env ファイルがある場合は自動的に読み込まれます
 npx cdk deploy
 
 # または環境変数を使用（コスト削減）

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -1,0 +1,15 @@
+# AWS Credentials
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_DEFAULT_REGION=ap-northeast-1
+
+# GitHub Token (Required if USE_SECRETS_MANAGER=false)
+GITHUB_TOKEN=
+
+# Deployment Configuration
+# Set to false to use GITHUB_TOKEN from environment variable instead of Secrets Manager
+USE_SECRETS_MANAGER=false
+
+# Optional: Override repository information
+# REPO_OWNER=i-Willink-Inc
+# REPO_NAME=next-amplify-starter-kit

--- a/infra/bin/app.ts
+++ b/infra/bin/app.ts
@@ -1,4 +1,9 @@
 #!/usr/bin/env node
+import 'source-map-support/register';
+import * as dotenv from 'dotenv';
+// Load environment variables from .env file
+dotenv.config();
+
 import * as cdk from 'aws-cdk-lib';
 import { AmplifyStack } from '../lib/amplify-stack';
 

--- a/infra/package.json
+++ b/infra/package.json
@@ -12,6 +12,7 @@
     "dependencies": {
         "aws-cdk-lib": "^2.173.4",
         "constructs": "^10.4.2",
+        "dotenv": "^17.2.3",
         "source-map-support": "^0.5.21"
     },
     "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       constructs:
         specifier: ^10.4.2
         version: 10.4.4
+      dotenv:
+        specifier: ^17.2.3
+        version: 17.2.3
       source-map-support:
         specifier: ^0.5.21
         version: 0.5.21
@@ -901,6 +904,10 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dotenv@17.2.3:
+    resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
+    engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -2760,6 +2767,8 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dotenv@17.2.3: {}
 
   dunder-proto@1.0.1:
     dependencies:


### PR DESCRIPTION
## 概要
開発体験向上のため、`infra` ディレクトリでの `.env` ファイルによる環境変数管理をサポートしました。

## 変更内容
- **infra/package.json**: `dotenv` パッケージを追加
- **infra/bin/app.ts**: アプリケーション起動時に `.env` を読み込むよう設定
- **infra/.env.example**: 環境変数のテンプレートを作成
- **docs/30_operations/deployment.md**: `.env` を利用したデプロイ手順を追加

## メリット
- ローカルデプロイ時に都度環境変数を export する必要がなくなります
- 認証情報や設定をファイルで一元管理できます
- `.gitignore` で除外されているため、誤ってコミットされるリスクがありません

## 使い方
```bash
cp infra/.env.example infra/.env
# infra/.env を編集
cd infra
npx cdk deploy
```