### PR TITLE
feat: Amplifyへの独自ドメイン設定機能を追加

### DIFF
--- a/docs/30_operations/deployment.md
+++ b/docs/30_operations/deployment.md
@@ -142,6 +142,31 @@ USE_SECRETS_MANAGER=false GITHUB_TOKEN=ghp_xxx npx cdk deploy
 
 ---
 
+## 独自ドメインの設定（オプション）
+
+Route53 に登録されているドメインを Amplify アプリに適用できます。
+設定すると、ルートドメイン (`example.com`) と `www` サブドメイン (`www.example.com`) が自動的に設定されます。
+
+> **前提**: 同一 AWS アカウントの Route53 に Hosted Zone が作成されていること。
+
+### 設定方法
+
+**ローカルデプロイ (.env)**
+```bash
+# infra/.env
+DOMAIN_NAME=example.com
+```
+
+**ローカルデプロイ (Context)**
+```bash
+npx cdk deploy -c domainName=example.com
+```
+
+**GitHub Actions**
+現在、環境変数 `DOMAIN_NAME` を渡す設定を追加する必要があります（必要に応じて workflow を修正してください）。
+
+---
+
 ## 前提となる権限設定
 
 デプロイには以下の権限が必要です。

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -13,3 +13,7 @@ USE_SECRETS_MANAGER=false
 # Optional: Override repository information
 # REPO_OWNER=i-Willink-Inc
 # REPO_NAME=next-amplify-starter-kit
+
+# Optional: Custom Domain (Route53)
+# DOMAIN_NAME=example.com
+


### PR DESCRIPTION
## 概要
Amplify Hosting に独自ドメイン（Route53）を設定する機能を追加しました。

## 変更内容
- **amplify-stack.ts**: `domainName` コンテキスト/環境変数が指定された場合、`CfnDomain` リソースを作成
- **.env.example**: `DOMAIN_NAME` の設定例を追加
- **deployment.md**: 独自ドメインの設定方法を追記

## 使い方
`.env` に以下を追記してデプロイします。
```
DOMAIN_NAME=example.com
```
※ Route53 Hosted Zone が同一アカウントに存在する必要があります。