### PR TITLE
fix: disable enableAutoBuild to prevent CI conflicts

### DIFF
--- a/infra/lib/amplify-stack.ts
+++ b/infra/lib/amplify-stack.ts
@@ -120,7 +120,7 @@ export class AmplifyStack extends cdk.Stack {
         this.mainBranch = new amplify.CfnBranch(this, 'MainBranch', {
             appId: this.amplifyApp.attrAppId,
             branchName: 'main',
-            enableAutoBuild: true,
+            enableAutoBuild: false,
             stage: 'PRODUCTION',
             framework: 'Next.js - SSR',
         });


### PR DESCRIPTION
Sets enableAutoBuild to false for the main branch. This prevents Amplify from automatically triggering builds, which causes conflicts with our manual CI/CD pipeline triggers and can lead to redundant or failed builds.