### PR TITLE
feat: add Playwright E2E testing infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,41 @@ jobs:
       - name: Run tests
         run: pnpm test
 
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    needs: test
+    if: ${{ needs.changes.outputs.apps == 'true' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        run: pnpm --filter web exec playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        run: pnpm --filter web test:e2e
+
+      - name: Upload Playwright report
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: playwright-report
+          path: apps/web/playwright-report/
+          retention-days: 7
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,8 @@ pnpm-debug.log*
 
 # Testing
 coverage/
+playwright-report/
+test-results/
 
 # Turbo
 .turbo/

--- a/apps/web/e2e/contact.spec.ts
+++ b/apps/web/e2e/contact.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Contact Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/contact');
+  });
+
+  test('should load the contact form', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('Contact Us');
+    await expect(page.getByLabel(/name/i)).toBeVisible();
+    await expect(page.getByLabel(/email/i)).toBeVisible();
+    await expect(page.getByLabel(/subject/i)).toBeVisible();
+    await expect(page.getByLabel(/message/i)).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Send Message' })).toBeVisible();
+  });
+
+  test('should allow filling in form fields', async ({ page }) => {
+    await page.getByLabel(/name/i).fill('Test User');
+    await expect(page.getByLabel(/name/i)).toHaveValue('Test User');
+
+    await page.getByLabel(/email/i).fill('test@example.com');
+    await expect(page.getByLabel(/email/i)).toHaveValue('test@example.com');
+
+    await page.getByLabel(/subject/i).fill('Test Subject');
+    await expect(page.getByLabel(/subject/i)).toHaveValue('Test Subject');
+
+    await page.getByLabel(/message/i).fill('Hello, this is a test message.');
+    await expect(page.getByLabel(/message/i)).toHaveValue('Hello, this is a test message.');
+  });
+
+  test('should display the demo badge', async ({ page }) => {
+    await expect(page.getByText('Demo page - Can be removed in production')).toBeVisible();
+  });
+
+  test('should have a back link to home', async ({ page }) => {
+    const backLink = page.getByRole('link', { name: /back to home/i });
+    await expect(backLink).toBeVisible();
+    await expect(backLink).toHaveAttribute('href', '/');
+  });
+});

--- a/apps/web/e2e/home.spec.ts
+++ b/apps/web/e2e/home.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Home Page', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('should display the main title', async ({ page }) => {
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Next.js Amplify');
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Starter Kit');
+  });
+
+  test('should display 3 feature cards', async ({ page }) => {
+    const cards = page.locator('h2');
+    await expect(cards).toHaveCount(3);
+    await expect(cards.nth(0)).toContainText('Turborepo');
+    await expect(cards.nth(1)).toContainText('AWS CDK');
+    await expect(cards.nth(2)).toContainText('Amplify');
+  });
+
+  test('should have external documentation links', async ({ page }) => {
+    const nextjsLink = page.getByRole('link', { name: 'Next.js Docs' });
+    await expect(nextjsLink).toBeVisible();
+    await expect(nextjsLink).toHaveAttribute('href', 'https://nextjs.org/docs');
+    await expect(nextjsLink).toHaveAttribute('target', '_blank');
+
+    const amplifyLink = page.getByRole('link', { name: 'Amplify Docs' });
+    await expect(amplifyLink).toBeVisible();
+    await expect(amplifyLink).toHaveAttribute('href', 'https://docs.amplify.aws/');
+    await expect(amplifyLink).toHaveAttribute('target', '_blank');
+  });
+
+  test('should have correct page metadata', async ({ page }) => {
+    await expect(page).toHaveTitle('Next.js Amplify Starter Kit');
+    const metaDescription = page.locator('meta[name="description"]');
+    await expect(metaDescription).toHaveAttribute(
+      'content',
+      'A modern monorepo starter kit with Next.js, AWS Amplify, and CDK'
+    );
+  });
+});

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Cross-Page Navigation', () => {
+  test('should navigate from home to contact page', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Next.js Amplify');
+
+    // Navigate to contact page
+    await page.goto('/contact');
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('Contact Us');
+  });
+
+  test('should navigate back from contact to home via back link', async ({ page }) => {
+    await page.goto('/contact');
+    await expect(page.getByRole('heading', { level: 1 })).toHaveText('Contact Us');
+
+    await page.getByRole('link', { name: /back to home/i }).click();
+    await expect(page).toHaveURL('/');
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Next.js Amplify');
+  });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,9 @@
     "lint": "eslint .",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "@aws-sdk/client-ses": "^3.700.0",
@@ -34,6 +36,7 @@
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.18",
     "typescript": "^5.7.2",
+    "@playwright/test": "^1.52.0",
     "vitest": "^4.0.16"
   }
 }

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: [['html', { open: 'never' }]],
+  timeout: 30_000,
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'pnpm dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/turbo.json
+++ b/turbo.json
@@ -15,6 +15,10 @@
     "test": {
       "dependsOn": ["^build"]
     },
+    "test:e2e": {
+      "dependsOn": ["^build"],
+      "cache": false
+    },
     "clean": {
       "cache": false
     }


### PR DESCRIPTION
## Summary
- Add Playwright config (Chromium-only, dev server integration)
- Add E2E tests for home page, contact page, and cross-page navigation
- Add `test:e2e` scripts to `apps/web/package.json` and `turbo.json`
- Add E2E job to CI pipeline with artifact upload on failure
- Update `.gitignore` for test artifacts

## E2E Tests
| File | Coverage |
|------|----------|
| `home.spec.ts` | Title, feature cards, external links, metadata |
| `contact.spec.ts` | Form fields, interaction, demo badge, back link |
| `navigation.spec.ts` | Cross-page navigation, back links |

## CI Integration
New `e2e` job runs after `build`, only when `apps/` files change. Uploads `playwright-report/` as artifact on failure.

## Test plan
- [ ] Run `pnpm --filter web test:e2e` locally
- [ ] Verify CI pipeline runs E2E job on PR
- [ ] Verify artifact upload on test failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)